### PR TITLE
Add netstandard2.0 to TargetFrameworks

### DIFF
--- a/src/sib_api_v3_sdk.Test/sib_api_v3_sdk.Test.csproj
+++ b/src/sib_api_v3_sdk.Test/sib_api_v3_sdk.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net45;netstandard2.0;</TargetFramework>
     <AssemblyName>sib_api_v3_sdk.Test</AssemblyName>
     <PackageId>sib_api_v3_sdk.Test</PackageId>
     <OutputType>Library</OutputType>

--- a/src/sib_api_v3_sdk/sib_api_v3_sdk.csproj
+++ b/src/sib_api_v3_sdk/sib_api_v3_sdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net45;netstandard2.0;</TargetFramework>
     <AssemblyName>sib_api_v3_sdk</AssemblyName>
     <PackageId>sib_api_v3_sdk</PackageId>
     <OutputType>Library</OutputType>


### PR DESCRIPTION
Add proper support for netstandard2.0 projects. Should be a simple addition since the dependencies used all already support netstandard2.0