### PR TITLE
Allow email campaign sender with email _or_ id

### DIFF
--- a/src/sib_api_v3_sdk/Model/CreateEmailCampaignSender.cs
+++ b/src/sib_api_v3_sdk/Model/CreateEmailCampaignSender.cs
@@ -41,15 +41,10 @@ namespace sib_api_v3_sdk.Model
         /// <param name="id">Select the sender for the campaign on the basis of sender id. In order to select a sender with specific pool of IP’s, dedicated ip users shall pass id (instead of email)..</param>
         public CreateEmailCampaignSender(string name = default(string), string email = default(string), long? id = default(long?))
         {
-            // to ensure "email" is required (not null)
-            if (email == null)
-            {
-                throw new InvalidDataException("email is a required property for CreateEmailCampaignSender and cannot be null");
-            }
-            else
-            {
-                this.Email = email;
-            }
+            if ((id == null && email == null) || (id != null && email != null))
+                throw new InvalidDataException("Either id or email must be specified for CreateEmailCampaignSender, but not both");
+
+            this.Email = email;
             this.Name = name;
             this.Id = id;
         }

--- a/src/sib_api_v3_sdk/Model/CreateEmailCampaignSender.cs
+++ b/src/sib_api_v3_sdk/Model/CreateEmailCampaignSender.cs
@@ -37,8 +37,8 @@ namespace sib_api_v3_sdk.Model
         /// Initializes a new instance of the <see cref="CreateEmailCampaignSender" /> class.
         /// </summary>
         /// <param name="name">Sender Name.</param>
-        /// <param name="email">Sender email (required).</param>
-        /// <param name="id">Select the sender for the campaign on the basis of sender id. In order to select a sender with specific pool of IP’s, dedicated ip users shall pass id (instead of email)..</param>
+        /// <param name="email">Sender email (required if id is not specified).</param>
+        /// <param name="id">Select the sender for the campaign on the basis of sender id. In order to select a sender with specific pool of IP’s, dedicated ip users shall pass id instead of email (required if email is not specified).</param>
         public CreateEmailCampaignSender(string name = default(string), string email = default(string), long? id = default(long?))
         {
             if ((id == null && email == null) || (id != null && email != null))

--- a/src/sib_api_v3_sdk/Model/CreateEmailCampaignSender.cs
+++ b/src/sib_api_v3_sdk/Model/CreateEmailCampaignSender.cs
@@ -33,20 +33,31 @@ namespace sib_api_v3_sdk.Model
         /// </summary>
         [JsonConstructorAttribute]
         protected CreateEmailCampaignSender() { }
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="CreateEmailCampaignSender" /> class.
+        /// Initializes a new instance of the <see cref="CreateEmailCampaignSender" /> class on the basis of sender id
+        /// </summary>
+        /// <param name="id">Select the sender for the campaign on the basis of sender id. In order to select a sender with specific pool of IP’s, dedicated ip users shall pass id instead of email (required if email is not specified).</param>
+        public CreateEmailCampaignSender(long id = default(long?))
+        {
+            if (id == null)
+                throw new InvalidDataException("id must be specified. Use alternative constructor if you want to specify the sender by email and optionally, name");
+
+            this.Id = id;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateEmailCampaignSender" /> class by specifying email and name (optional)
         /// </summary>
         /// <param name="name">Sender Name.</param>
-        /// <param name="email">Sender email (required if id is not specified).</param>
-        /// <param name="id">Select the sender for the campaign on the basis of sender id. In order to select a sender with specific pool of IP’s, dedicated ip users shall pass id instead of email (required if email is not specified).</param>
-        public CreateEmailCampaignSender(string name = default(string), string email = default(string), long? id = default(long?))
+        /// <param name="email">Sender email (required).</param>
+        public CreateEmailCampaignSender(string name = default(string), string email = default(string))
         {
-            if ((id == null && email == null) || (id != null && email != null))
-                throw new InvalidDataException("Either id or email must be specified for CreateEmailCampaignSender, but not both");
+            if (email == null)
+                throw new InvalidDataException("email must be specified. Use alternative constructor if you want to specify the sender by sender id.");
 
             this.Email = email;
             this.Name = name;
-            this.Id = id;
         }
         
         /// <summary>


### PR DESCRIPTION
The documentation for `CreateEmailCampaignSender` states:

> Sender details including id or email and name (optional). Only one of either Sender's email or Sender's ID shall be passed in one request at a time.

At present, this library requires you to specify the sender 'email' or else it fails with an `InvalidDataException` in the constructor. It's not currently possible then, to use this library to create a sender with an `id` as if you send through a `CreateEmailCampaignSender` with both the 'email' and 'id' specified, the API replies with a failed response:

> Only one of Sender ID or Sender Email can be passed for the same request.

This PR updates the `CreateEmailCampaignSender` so that it complies with the documentation and the API requirements. There are now two constructors for `CreateEmailCampaignSender`, one for instantiating a sender based on `id` and another based on `email` and `name`. This should help clear up any ambiguity and will allow you to use the library to create a sender on the basis of id as per the documentation.