### PR TITLE
Added StatusCode to ApiException message

### DIFF
--- a/src/sib_api_v3_sdk/Client/Configuration.cs
+++ b/src/sib_api_v3_sdk/Client/Configuration.cs
@@ -54,7 +54,7 @@ namespace sib_api_v3_sdk.Client
             if (status >= 400)
             {
                 return new ApiException(status,
-                    string.Format("Error calling {0}: {1}", methodName, response.Content),
+                    string.Format("Error calling {0}. StatusCode {1}: {2}", methodName, response.StatusCode, response.Content),
                     response.Content);
             }
             


### PR DESCRIPTION
When an API call fails, the resulting message provides very little information if there is no content (as was the case with a recent error from the API). This made it impossible to tell the key contextual information about the error, i.e. is it a true API error, is it rate limiting, is it a 400 bad request, etc. without specifically handling an ApiException in code and looking at those properties. Since we're already putting details in the exception message, we should also consider also putting the HttpStatus in there as well as that is a first-class citizen of a response.